### PR TITLE
fix: resolve staticDirs path issue in Storybook configuration

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite';
+import path from 'path';
 
 const config: StorybookConfig = {
   stories: [
@@ -17,7 +18,7 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
-  staticDirs: ['../public'],
+  staticDirs: [path.resolve(__dirname, '../public')],
   typescript: {
     check: false,
   },


### PR DESCRIPTION
- Use path.resolve() for absolute path resolution in staticDirs
- Add path import to handle directory resolution correctly
- Fixes build failure in CI/CD pipeline where relative paths fail